### PR TITLE
Adapt for LibreTuya compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
   "version": "1.2.2",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
-  "platforms": "espressif32",
+  "platforms": ["espressif32", "libretuya"],
   "build": {
     "libCompatMode": 2
   }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -29,7 +29,9 @@ extern "C"{
 #include "lwip/dns.h"
 #include "lwip/err.h"
 }
+#if CONFIG_ASYNC_TCP_USE_WDT
 #include "esp_task_wdt.h"
+#endif
 
 /*
  * TCP/IP Event Task
@@ -704,8 +706,12 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
     }
 
     ip_addr_t addr;
+#if LWIP_IPV4 && LWIP_IPV6
     addr.type = IPADDR_TYPE_V4;
     addr.u_addr.ip4.addr = ip;
+#else
+    addr.addr = ip;
+#endif
 
     tcp_pcb* pcb = tcp_new_ip_type(IPADDR_TYPE_V4);
     if (!pcb){
@@ -733,7 +739,11 @@ bool AsyncClient::connect(const char* host, uint16_t port){
     
     err_t err = dns_gethostbyname(host, &addr, (dns_found_callback)&_tcp_dns_found, this);
     if(err == ERR_OK) {
+#if LWIP_IPV4 && LWIP_IPV6
         return connect(IPAddress(addr.u_addr.ip4.addr), port);
+#else
+        return connect(IPAddress(addr.addr), port);
+#endif
     } else if(err == ERR_INPROGRESS) {
         _connect_port = port;
         return true;
@@ -998,8 +1008,13 @@ int8_t AsyncClient::_poll(tcp_pcb* pcb){
 }
 
 void AsyncClient::_dns_found(struct ip_addr *ipaddr){
+#if LWIP_IPV4 && LWIP_IPV6
     if(ipaddr && ipaddr->u_addr.ip4.addr){
         connect(IPAddress(ipaddr->u_addr.ip4.addr), _connect_port);
+#else
+    if (ipaddr && ipaddr->addr){
+        connect(IPAddress(ipaddr->addr), _connect_port);
+#endif
     } else {
         if(_error_cb) {
             _error_cb(_error_cb_arg, this, -55);
@@ -1088,7 +1103,11 @@ uint32_t AsyncClient::getRemoteAddress() {
     if(!_pcb) {
         return 0;
     }
+#if LWIP_IPV4 && LWIP_IPV6
     return _pcb->remote_ip.u_addr.ip4.addr;
+#else
+    return _pcb->remote_ip.addr;
+#endif
 }
 
 uint16_t AsyncClient::getRemotePort() {
@@ -1102,7 +1121,11 @@ uint32_t AsyncClient::getLocalAddress() {
     if(!_pcb) {
         return 0;
     }
+#if LWIP_IPV4 && LWIP_IPV6
     return _pcb->local_ip.u_addr.ip4.addr;
+#else
+    return _pcb->local_ip.addr;
+#endif
 }
 
 uint16_t AsyncClient::getLocalPort() {
@@ -1298,8 +1321,12 @@ void AsyncServer::begin(){
     }
 
     ip_addr_t local_addr;
+#if LWIP_IPV4 && LWIP_IPV6
     local_addr.type = IPADDR_TYPE_V4;
     local_addr.u_addr.ip4.addr = (uint32_t) _addr;
+#else
+    local_addr.addr = (uint32_t) _addr;
+#endif
     err = _tcp_bind(_pcb, &local_addr, _port);
 
     if (err != ERR_OK) {

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -240,7 +240,7 @@ static bool _start_async_task(){
         return false;
     }
     if(!_async_service_task_handle){
-        customTaskCreateUniversal(_async_service_task, "async_tcp", 8192 * 2, NULL, 3, &_async_service_task_handle, CONFIG_ASYNC_TCP_RUNNING_CORE);
+        customTaskCreateUniversal(_async_service_task, "async_tcp", CONFIG_ASYNC_TCP_STACK_SIZE, NULL, 3, &_async_service_task_handle, CONFIG_ASYNC_TCP_RUNNING_CORE);
         if(!_async_service_task_handle){
             return false;
         }

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -23,12 +23,22 @@
 #define ASYNCTCP_H_
 
 #include "IPAddress.h"
-#include "sdkconfig.h"
 #include <functional>
+
+#ifndef LIBRETUYA
+#include "sdkconfig.h"
 extern "C" {
     #include "freertos/semphr.h"
     #include "lwip/pbuf.h"
 }
+#else
+extern "C" {
+    #include <semphr.h>
+    #include <lwip/pbuf.h>
+}
+#define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
+#define CONFIG_ASYNC_TCP_USE_WDT 0
+#endif
 
 //If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -46,6 +46,10 @@ extern "C" {
 #define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
 #endif
 
+#ifndef CONFIG_ASYNC_TCP_STACK_SIZE
+#define CONFIG_ASYNC_TCP_STACK_SIZE 8192 * 2
+#endif
+
 class AsyncClient;
 
 #define ASYNC_MAX_ACK_TIME 5000


### PR DESCRIPTION
(see [esphome#3509](https://github.com/esphome/esphome/pull/3509))

This also fixes usage of lwIP without IPv6 enabled, which uses a different ip_addr struct, which has no `type` and `u_addr` fields.