### PR TITLE
Arduino 3 / ESP IDF 5 compatibility

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,28 +2,51 @@ name: Async TCP CI
 
 on:
   push:
-    branches:
   pull_request:
+  workflow_dispatch:
 
 jobs:
-
   build-arduino:
-    name: Arduino on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        config: [arduino-cli.yaml, arduino-cli-dev.yaml]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: arduino/setup-arduino-cli@v1
       - name: Download board
         run: |
-          arduino-cli --config-file arduino-cli.yaml core update-index
-          arduino-cli --config-file arduino-cli.yaml board listall
-          arduino-cli --config-file arduino-cli.yaml core install esp32:esp32@2.0.2
+          arduino-cli --config-file ${{ matrix.config }} core update-index
+          arduino-cli --config-file ${{ matrix.config }} board listall
+          arduino-cli --config-file ${{ matrix.config }} core install esp32:esp32
       - name: Compile Sketch
-        run: arduino-cli --config-file arduino-cli.yaml --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
+        run: arduino-cli --config-file ${{ matrix.config }} --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
       - name: Compile Sketch with IPv6
         env:
           LWIP_IPV6: true
-        run: arduino-cli --config-file arduino-cli.yaml --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
+        run: arduino-cli --config-file ${{ matrix.config }} --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
+
+  build-pio:
+    name: ${{ matrix.board }} ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [esp32dev, esp32-s3-devkitc-1]
+        env: [arduino-2, arduino-3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: ${{ matrix.env }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install platformio
+      - run: sed -i -e 's/esp32dev/${{ matrix.board }}/g' platformio.ini
+      - run: pio run -e ${{ matrix.env }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-
 .DS_Store
+.lh
+/.pio
+/.vscode/*
+!/.vscode/settings.json
+/logs

--- a/arduino-cli-dev.yaml
+++ b/arduino-cli-dev.yaml
@@ -1,0 +1,25 @@
+board_manager:
+  additional_urls:
+    - https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json
+directories:
+  builtin.libraries: ./src/
+build_cache:
+  compilations_before_purge: 10
+  ttl: 720h0m0s
+daemon:
+  port: "50051"
+library:
+  enable_unsafe_install: false
+logging:
+  file: ""
+  format: text
+  level: info
+metrics:
+  addr: :9090
+  enabled: true
+output:
+  no_color: false
+sketch:
+  always_export_binaries: false
+updater:
+  enable_notification: true

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+me=AsyncTCP-esphome
+version=2.1.3
+author=Me-No-Dev
+maintainer=ESPHome
+sentence=Async TCP Library for ESP32
+paragraph=Async TCP Library for ESP32
+category=Other
+url=https://github.com/esphome/AsyncTCP.git
+architectures=*

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,28 @@
+[env]
+framework = arduino
+build_flags = 
+  -Wall -Wextra
+  -D CONFIG_ARDUHAL_LOG_COLORS
+  -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+upload_protocol = esptool
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder, log2file
+
+[platformio]
+lib_dir = .
+src_dir = examples/ClientServer/Client
+
+[env:arduino]
+platform = espressif32
+board = esp32dev
+
+[env:arduino-2]
+platform = espressif32@6.7.0
+board = esp32dev
+
+[env:arduino-3]
+platform = espressif32
+platform_packages=
+  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0
+  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip
+board = esp32dev


### PR DESCRIPTION
This PR proposes some changes to allow the AsyncTCP lib to be compatible with Arduino 3 / ESP IDF 5 that will be released next.

Sadly, the `IPv6Address` class has been removed...

I've tried to keep the API as close as possible, so that users will just have to update from `IPv6Address` to `IPAddress` which is now used for both types (and this is also what many other languages also do).

I would have preferred that the removal were done in a deprecating and backward compatible way instead of breaking the API like the butchery job they did. I think they should have kept this `IPv6Address`, enhanced the `IPAddress` class (and make it a super class) and introduce a `IPv4Address` class. The Java language has a pretty good example of abstraction already working since years.

In this PR I also updated the CI job to build with both the released version and dev version of espressif / arduino.

Compilation pass in my fork, but the changes in this PR were not tested with IPv6 (only with Pv4 and Arduino 3).