### PR TITLE
xQueueHandle => QueueHandle_t

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -78,7 +78,7 @@ typedef struct {
         };
 } lwip_event_packet_t;
 
-static xQueueHandle _async_queue;
+static QueueHandle_t _async_queue;
 static TaskHandle_t _async_service_task_handle = NULL;
 
 


### PR DESCRIPTION
`xQueueHandle` relies on `configENABLE_BACKWARD_COMPATIBILITY` to be set which is not always the case for customised Arduino builds, and thus fails to compile.

```c++
/* Definitions to allow backward compatibility with FreeRTOS versions prior to
 * V8 if desired. */
#ifndef configENABLE_BACKWARD_COMPATIBILITY
    #define configENABLE_BACKWARD_COMPATIBILITY    1
#endif
```