### PR TITLE
Improve CI to also build with latest platformio / arduino versions and also several boards

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,28 +2,51 @@ name: Async TCP CI
 
 on:
   push:
-    branches:
   pull_request:
+  workflow_dispatch:
 
 jobs:
-
   build-arduino:
-    name: Arduino on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        config: [arduino-cli.yaml, arduino-cli-dev.yaml]
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-arduino-cli@v1
       - name: Download board
         run: |
-          arduino-cli --config-file arduino-cli.yaml core update-index
-          arduino-cli --config-file arduino-cli.yaml board listall
-          arduino-cli --config-file arduino-cli.yaml core install esp32:esp32@2.0.2
+          arduino-cli --config-file ${{ matrix.config }} core update-index
+          arduino-cli --config-file ${{ matrix.config }} board listall
+          arduino-cli --config-file ${{ matrix.config }} core install esp32:esp32
       - name: Compile Sketch
-        run: arduino-cli --config-file arduino-cli.yaml --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
+        run: arduino-cli --config-file ${{ matrix.config }} --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
       - name: Compile Sketch with IPv6
         env:
           LWIP_IPV6: true
-        run: arduino-cli --config-file arduino-cli.yaml --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
+        run: arduino-cli --config-file ${{ matrix.config }} --library ./src/ compile --fqbn esp32:esp32:esp32 ./examples/ClientServer/Client/Client.ino
+
+  build-pio:
+    name: ${{ matrix.board }} ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [esp32dev, esp32-s3-devkitc-1]
+        env: [v660, latest-espressif32, latest-arduino, v300-rc1]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: ${{ matrix.env }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install platformio
+      - run: sed -i -e 's/esp32dev/${{ matrix.board }}/g' platformio.ini
+      - run: pio run -e ${{ matrix.env }}

--- a/arduino-cli-dev.yaml
+++ b/arduino-cli-dev.yaml
@@ -1,0 +1,25 @@
+board_manager:
+  additional_urls:
+    - https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json
+directories:
+  builtin.libraries: ./src/
+build_cache:
+  compilations_before_purge: 10
+  ttl: 720h0m0s
+daemon:
+  port: "50051"
+library:
+  enable_unsafe_install: false
+logging:
+  file: ""
+  format: text
+  level: info
+metrics:
+  addr: :9090
+  enabled: true
+output:
+  no_color: false
+sketch:
+  always_export_binaries: false
+updater:
+  enable_notification: true

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,35 @@
+[env]
+framework = arduino
+build_flags = 
+  -Wall -Wextra
+  -D CONFIG_ARDUHAL_LOG_COLORS
+  -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+upload_protocol = esptool
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder, log2file
+
+[platformio]
+lib_dir = .
+src_dir = examples/ClientServer/Client
+
+[env:v660]
+platform = espressif32@6.6.0
+board = esp32dev
+
+[env:latest-espressif32]
+platform = https://github.com/platformio/platform-espressif32.git
+board = esp32dev
+
+[env:latest-arduino]
+platform = espressif32
+platform_packages=
+  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#master
+  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
+board = esp32dev
+
+[env:v300-rc1]
+platform = espressif32
+platform_packages=
+  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-rc1
+  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
+board = esp32dev


### PR DESCRIPTION
This PR add a more exhaustive CI against Arduino 2 and 3 and will show that the current state of main is not compatible with Arduino 3.

The CI will pass with #11.